### PR TITLE
Update namespace and package name from Generico\Theme to D2\Generico

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2018-08-02
+
+### Changed
+
+* Update namespace and package name from Generico\Theme to D2\Generico.
+
 ## [0.2.0] - 2018-07-31
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Generico\\Theme\\": "src/"
+      "D2\\Generico\\": "src/"
     }
   }
 }

--- a/config/defaults.php
+++ b/config/defaults.php
@@ -2,13 +2,13 @@
 /**
  * Theme config file.
  *
- * @package   Generico\Theme
+ * @package   D2\Generico
  * @author    Craig Simpson <craig@craigsimpson.scot>
  * @copyright Copyright (c) 2018, Craig Simpson
  * @license   MIT
  */
 
-namespace Generico\Theme;
+namespace D2\Generico;
 
 use D2\Core\AssetLoader;
 use D2\Core\GenesisCustomizer;

--- a/functions.php
+++ b/functions.php
@@ -2,13 +2,13 @@
 /**
  * Theme functions file.
  *
- * @package   Generico\Theme
+ * @package   D2\Generico
  * @author    Craig Simpson <craig@craigsimpson.scot>
  * @copyright Copyright (c) 2018, Craig Simpson
  * @license   MIT
  */
 
-namespace Generico\Theme;
+namespace D2\Generico;
 
 define( 'CHILD_THEME_NAME', 'Generico' );
 define( 'CHILD_THEME_URL', 'https://github.com/d2themes/generico' );


### PR DESCRIPTION
Just a suggestion - to keep namespaces/package names the same across all projects.